### PR TITLE
Fix- move isseus api endpoint to "issues" folder.

### DIFF
--- a/pages/api/issues/index.js
+++ b/pages/api/issues/index.js
@@ -2,7 +2,7 @@
 import prisma from "@/prisma/client";
 import multer from "multer";
 import fs from "fs";
-import { cloudinary } from "./utils/cloudinary";
+import { cloudinary } from "../utils/cloudinary";
 
 const upload = multer({ dest: "uploads/" });
 

--- a/pages/api/issues/index.js
+++ b/pages/api/issues/index.js
@@ -4,7 +4,7 @@ import multer from "multer";
 import fs from "fs";
 import { cloudinary } from "../utils/cloudinary";
 
-const upload = multer({ dest: "uploads/" });
+const upload = multer({ dest: "/tmp" });
 
 export const config = {
   api: {


### PR DESCRIPTION
# What this pull request does

## What

In the deployment version of the the app, an error "status 405" occurs when trying to post a new issue. There was also the following error "Error: EROFS: read-only file system, mkdir(...)".

## Why

Although posting a new issue is not a problem in the localhost, it must also be possible in deployment version.

## How

- the api folder structure was not quite right nested, so the "index.js" file is now correctly placed inside the "issues" folder
- also, the upload images were previously stored in the root "uploads/" folder, which didn't work for the deployment version, so that now it is done in a "/tmp" folder.
- the mentioned "EROFS" error can be solved following the instructions from this website: [Solving ERROFS](https://github.com/orgs/vercel/discussions/314)

## Steppings to test this

Go to the deployment version and post a new issue (with or without an image). Then a double check can be done in the "/admin" (list of issues) page that shall display the new issue, as well checking out the insertion of the new issue and related initial update in the database.

## Anything else

It is good to keep in mind that such issues may occur in other deployment situations, specially with regards to the "/tmp" folder instead of the "uploads/" one.
