### PR TITLE
Styling- Admin TopBar better styled.

### DIFF
--- a/components/Admin/Nav/AdminTopBar/AdminTopBar.module.css
+++ b/components/Admin/Nav/AdminTopBar/AdminTopBar.module.css
@@ -55,6 +55,8 @@
   .main {
     flex-direction: column;
     margin-bottom: 0;
+    height: 100vh;
+    position: fixed;
   }
 
   .profile {


### PR DESCRIPTION
# What this pull request does

## What

The Admin bar on the desktop version was appearing  on the side of the screen. Depending on the number of the posted issues it may be necessary to scroll the page down to see the logout icon and the admin's avatar. 
This commit aims to fix this issue by improving the Admin TopBar's design.

## Why

The need to scroll down the screen to see the logout icon and the avatar in case many issues are listed can be tiresome for the user, so we can enhance the page's layout.

## How

The Admin bar can be better styled (using the existing CSS class) by setting a height of 100vh and adding the property "position: fixed" to it. This way, when the admin scrolls the page up and down, in the desktop version, the Admin Bar stays as whole in the left side of the screen, whereas the list of issues scroll along the screen.
 
## Steppings to test this

Go to the "/admin" page and scroll the screen up and down (ideally with a long list of issues). The Admin bar will stay entirely visible on the left side of the screen.

## Anything else

Check out the attached demo video.



https://github.com/luizfiorentino/my-city-app/assets/96445830/9941c0fe-6e7b-4ce4-b4ed-21668c022983

