### PR TITLE
Vercel deployment domain added to white list of Open Cage api  calls

### DIFF
--- a/pages/api/geolocation.js
+++ b/pages/api/geolocation.js
@@ -4,7 +4,10 @@ const apiKey = process.env.OPENCAGE_API_KEY;
 const rateLimitWindowMs = 60000;
 const maxRequestsPerWindow = 100;
 const rateLimits = new Map();
-const allowedDomains = ["http://localhost:3000", "subdomain.example.com"];
+const allowedDomains = [
+  "http://localhost:3000",
+  "https://my-city-app.vercel.app/",
+];
 
 export default async function handler(req, res) {
   const { latitude, longitude } = req.query;


### PR DESCRIPTION
# What this pull request does

## What

The Vercel domain `https://my-city-app.vercel.app/` is added to the list of authorised ones to make api calls to Open Cage.
 
## Why

The coordinates provided by the user can be sent in the api call that returns the address to be used in the Admin List and Details Page.

## How

Simply adding the Vercel domain to the whitelist in the variable `allowedDomains` in the `geolocation` component.

## Steppings to test this

Post an issue in the deployment version, go to the list of issues and the Details Page, where the actual address of the pinned location will show up.

## Anything else

-
